### PR TITLE
Update moveit2.repos

### DIFF
--- a/moveit2.repos
+++ b/moveit2.repos
@@ -47,10 +47,6 @@ repositories:
     type: git
     url: https://github.com/ros2/console_bridge_vendor
     version: crystal
-  ros1_bridge:
-    type: git
-    url: https://github.com/ros2/ros1_bridge
-    version: master
   image_common:
     type: git
     url: https://github.com/ros-perception/image_common


### PR DESCRIPTION
Since it is no more needed, lets remove it, it is making the CI fail such as https://travis-ci.org/AcutronicRobotics/moveit2/jobs/527214797

The only place that it is "needed" is on [perception](https://github.com/AcutronicRobotics/moveit2/blob/updaterepos/moveit_ros/perception/CMakeLists.txt#L30) but it's commented.