### PR TITLE
Add rviz debs to ci Dockerfile

### DIFF
--- a/.docker/ci/Dockerfile
+++ b/.docker/ci/Dockerfile
@@ -42,6 +42,10 @@ RUN \
          ros-$ROS_DISTRO-message-filters \
          ros-$ROS_DISTRO-rclcpp-action \
          ros-$ROS_DISTRO-resource-retriever \
+         ros-$ROS_DISTRO-rviz-common \
+         ros-$ROS_DISTRO-rviz-default-plugins \
+         ros-$ROS_DISTRO-rviz-ogre-vendor \
+         ros-$ROS_DISTRO-rviz-rendering \
          libompl-dev \
       && rm -rf /var/lib/apt/lists/*
       # && mkdir -p $ROS_WS/src \


### PR DESCRIPTION
These 4 deb packages are the minimum required debs needed to compile the moveit visualization package.

Needed to pass CI in https://github.com/AcutronicRobotics/moveit2/pull/101