### PR TITLE
Update CI infrastructure

### DIFF
--- a/.docker/ci/Dockerfile
+++ b/.docker/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ros:dashing
 
 LABEL maintainer="Lander Usategui lander@erlerobotics.com"
 
@@ -11,66 +11,21 @@ ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
 RUN \
-     echo 'Etc/UTC' > /etc/timezone \
-      && ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime \
-      && apt-get update -qq && apt-get install -qq -y tzdata dirmngr gnupg2 lsb-release curl \
-      # setup ros2 keys
-      && curl http://repo.ros2.org/repos.key | apt-key add - \
-      # setup sources.list
-      && echo "deb [arch=amd64,arm64] http://packages.ros.org/ros2/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list \
-      && apt-get update -qq && apt-get install -qq -y \
-         build-essential \
-         cmake \
-         git \
-         python3-colcon-common-extensions \
-         python3-pip \
-         python3-vcstool \
-         python3-wstool \
-         python-rosdep \
+       apt-get update -qq && apt-get install -qq -y \
          wget \
-      	 libboost-all-dev \
-         libglew-dev \
-         freeglut3-dev \
-         pkg-config \
-         libfcl-dev \
-         libassimp-dev \
-         libqhull-dev \
-         libopencv-dev \
          clang clang-format-3.9 clang-tidy clang-tools \
-         ros-$ROS_DISTRO-ros-base \
-         ros-$ROS_DISTRO-action-msgs \
-         ros-$ROS_DISTRO-message-filters \
-         ros-$ROS_DISTRO-rclcpp-action \
-         ros-$ROS_DISTRO-resource-retriever \
-         ros-$ROS_DISTRO-rviz-common \
-         ros-$ROS_DISTRO-rviz-default-plugins \
-         ros-$ROS_DISTRO-rviz-ogre-vendor \
-         ros-$ROS_DISTRO-rviz-rendering \
-         libompl-dev \
       && rm -rf /var/lib/apt/lists/*
-      # && mkdir -p $ROS_WS/src \
-      # && wget https://raw.githubusercontent.com/AcutronicRobotics/moveit2/master/moveit2.repos \
-      # && vcs import src < moveit2.repos
-
-# Install Fast-RTPS dependencies
-RUN apt-get -qq update && \
-        apt-get install -qq --no-install-recommends -y \
-            libasio-dev \
-            libtinyxml2-dev \
-            && \
-            # Clear apt-cache to reduce image size
-            rm -rf /var/lib/apt/lists/*
 
 # Download moveit source, so that we can get necessary dependencies
 RUN mkdir -p $ROS_WS/src \
     && wget https://raw.githubusercontent.com/AcutronicRobotics/moveit2/master/moveit2.repos \
-    && vcs import src < moveit2.repos
+    && vcs import src < moveit2.repos \
+    && cd src && git clone https://github.com/AcutronicRobotics/moveit2
     # wstool init --shallow . https://raw.githubusercontent.com/ros-planning/moveit2/master/moveit.rosinstall
 
 # Download all MoveIt 2 dependencies
 RUN \
     apt-get -qq update && \
-    rosdep init && \
     rosdep update -q && \
     rosdep install -q -y --from-paths . --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false || true && \
     # Clear apt-cache to reduce image size
@@ -85,10 +40,5 @@ RUN cd $ROS_WS && \
 # Continous Integration Setting
 ENV IN_DOCKER 1
 ENV DOCKER 1 # old version, keep for now
-
-# setup entrypoint https://github.com/docker/hub-feedback/issues/811
-#RUN echo '#!/bin/bash\nset -e\nsource "/opt/ros/$ROS_DISTRO/setup.bash"\nexec "$@"' > /docker-entrypoint.sh && chmod +x /docker-entrypoint.sh
-COPY ./docker-entrypoint.sh /
-ENTRYPOINT ["/docker-entrypoint.sh"]
 
 CMD ["bash"]

--- a/.docker/ci/docker-entrypoint.sh
+++ b/.docker/ci/docker-entrypoint.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -e
-
-
-find /opt/ros/$ROS_DISTRO -name tf2* | xargs rm -rf && find /opt/ros/$ROS_DISTRO/ -name class_loader | xargs rm -rf && find /opt/ros/$ROS_DISTRO -name pluginlib | xargs rm -rf
-# setup ros2 environment
-source "/opt/ros/$ROS_DISTRO/setup.bash"
-exec "$@"


### PR DESCRIPTION
* Remove unnecessary docker-entrypoint.sh (new base includes)
* Change FROM command to use officual docker image
* Remove keys etc
* Remove dependencies
* Use rosdep to install all the requirements to build MoveIt 2
* Remove rosdep init (done on base image)
* Remove copy entrypoint

Signed-off-by: Lander Usategui <lander.usategui@gmail.com>
