### PR TITLE
[visualization] remove warnings + minor CMakeLists fix

### DIFF
--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/current_state_monitor.h
@@ -50,7 +50,7 @@
 namespace planning_scene_monitor
 {
 
-typedef std::function<void(const sensor_msgs::msg::JointState::ConstPtr& joint_state)> JointStateUpdateCallback;
+typedef std::function<void(const sensor_msgs::msg::JointState::ConstSharedPtr& joint_state)> JointStateUpdateCallback;
 
 /** @class CurrentStateMonitor
     @brief Monitors the joint_states topic and tf to maintain the current state of the robot. */

--- a/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
+++ b/moveit_ros/planning/planning_scene_monitor/include/moveit/planning_scene_monitor/planning_scene_monitor.h
@@ -530,7 +530,7 @@ private:
   void scenePublishingThread();
 
   // called by current_state_monitor_ when robot state (as monitored on joint state topic) changes
-  void onStateUpdate(const sensor_msgs::msg::JointState::ConstPtr& /*joint_state*/);
+  void onStateUpdate(const sensor_msgs::msg::JointState::ConstSharedPtr& /*joint_state*/);
 
   // called by state_update_timer_ when a state update it pending
   void stateUpdateTimerCallback(/*const ros::WallTimerEvent& event*/);

--- a/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
+++ b/moveit_ros/planning/planning_scene_monitor/src/planning_scene_monitor.cpp
@@ -1174,7 +1174,7 @@ void PlanningSceneMonitor::stopStateMonitor()
   // }
 }
 
-void PlanningSceneMonitor::onStateUpdate(const sensor_msgs::msg::JointState::ConstPtr& /*joint_state */)
+void PlanningSceneMonitor::onStateUpdate(const sensor_msgs::msg::JointState::ConstSharedPtr& /*joint_state */)
 {
   const std::chrono::system_clock::time_point& n = std::chrono::system_clock::now();
   std::chrono::duration<double> dt = n - last_robot_state_update_wall_time_;

--- a/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
+++ b/moveit_ros/visualization/robot_state_rviz_plugin/src/robot_state_display.cpp
@@ -169,11 +169,6 @@ void RobotStateDisplay::changedEnableCollisionVisible()
   robot_->setCollisionVisible(enable_collision_visible_->getBool());
 }
 
-static bool operator!=(const std_msgs::msg::ColorRGBA& a, const std_msgs::msg::ColorRGBA& b)
-{
-  return a.r != b.r || a.g != b.g || a.b != b.b || a.a != b.a;
-}
-
 void RobotStateDisplay::setRobotHighlights(const moveit_msgs::msg::DisplayRobotState::_highlight_links_type& highlight_links)
 {
   if (highlight_links.empty() && highlights_.empty())

--- a/moveit_ros/visualization/trajectory_rviz_plugin/CMakeLists.txt
+++ b/moveit_ros/visualization/trajectory_rviz_plugin/CMakeLists.txt
@@ -8,7 +8,7 @@ set(HEADERS
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 # Trajectory Display
-add_library(${MOVEIT_LIB_NAME}
+add_library(${MOVEIT_LIB_NAME} SHARED
   src/trajectory_display.cpp
   ${HEADERS}
 )


### PR DESCRIPTION
### Description
Merge master branch and remove various moveit_ros_visualization related warnings.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extended the tutorials / documentation, if necessary [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Include a screenshot if changing a GUI
- [ ] Document API changes relevant to the user in the moveit/MIGRATION.md notes
- [ ] Created tests, which fail without this PR [reference](http://docs.ros.org/kinetic/api/moveit_tutorials/html/doc/tests.html)
- [ ] Decide if this should be cherry-picked to other current ROS branches
- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
